### PR TITLE
CS-128: Use absolute URLs in README.md for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ poetry run sphinx-build -b html docs/source docs/build
 ## Contributing
 
 We welcome contributions to the SpaceLink project! See 
-[CONTRIBUTING.md](CONTRIBUTING.md) for detailed instructions and guidelines.
+[CONTRIBUTING.md](https://github.com/cascade-space-co/spacelink/blob/main/CONTRIBUTING.md) for detailed instructions and guidelines.
 
 ## License
 
-[MIT License](LICENSE)
+[MIT License](https://github.com/cascade-space-co/spacelink/blob/main/LICENSE)
 


### PR DESCRIPTION
Relative links in the README don't work on PyPI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cascade-space-co/spacelink/25)
<!-- Reviewable:end -->
