### PR TITLE
Add G/T handling to antenna module

### DIFF
--- a/notebooks/theory/antenna.ipynb
+++ b/notebooks/theory/antenna.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,17 +35,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The gain of a 3.7 m dish at 2.25 GHz is 36.9 dB\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "frequency = 2.25 * u.GHz\n",
     "dish_diameter = 3.7 * u.m\n",
@@ -64,17 +56,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Polarization loss for 3.00 dB dB axial ratio: 0.51 dB\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "axial_ratio = 3.0 * u.dB\n",
     "polarization_loss = antenna.polarization_loss(axial_ratio, axial_ratio)\n",
@@ -173,7 +157,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -187,7 +171,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/theory/antenna.ipynb
+++ b/notebooks/theory/antenna.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,9 +35,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The gain of a 3.7 m dish at 2.25 GHz is 36.9 dB\n"
+     ]
+    }
+   ],
    "source": [
     "frequency = 2.25 * u.GHz\n",
     "dish_diameter = 3.7 * u.m\n",
@@ -50,15 +58,56 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "There are also helper funcitons to calculate the gain from the ratio of gain to the noise and temperature, and vice versa."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The gain is 34.8 dB from a 10.0 dB G/T ratio at 300.00 K\n",
+      "The temperature is 3.2 K from a gain of 15.0 dB and G/T ratio of 10.00 dB\n"
+     ]
+    }
+   ],
+   "source": [
+    "g_over_t = 10 * u.dB\n",
+    "\n",
+    "temperature = 300 * u.K\n",
+    "gain = antenna.gain_from_g_over_t(g_over_t, temperature)\n",
+    "print(f\"The gain is {gain:0.1f} from a {g_over_t:0.1f} G/T ratio at {temperature:0.2f}\")\n",
+    "\n",
+    "gain = 15 * u.dB\n",
+    "temperature = antenna.temperature_from_g_over_t(g_over_t, gain)\n",
+    "print(f\"The temperature is {temperature:0.1f} from a gain of {gain:0.1f} and G/T ratio of {g_over_t:0.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Next we can calculate the loss resulting from axial ratio mismatch between two antennas\n",
     "assuming worst-case orientations of the polarization ellipses (90° apart)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Polarization loss for 3.00 dB dB axial ratio: 0.51 dB\n"
+     ]
+    }
+   ],
    "source": [
     "axial_ratio = 3.0 * u.dB\n",
     "polarization_loss = antenna.polarization_loss(axial_ratio, axial_ratio)\n",
@@ -157,7 +206,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -171,7 +220,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/theory/antenna.ipynb
+++ b/notebooks/theory/antenna.ipynb
@@ -58,39 +58,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are also helper funcitons to calculate the gain from the ratio of gain to the noise and temperature, and vice versa."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The gain is 34.8 dB from a 10.0 dB G/T ratio at 300.00 K\n",
-      "The temperature is 3.2 K from a gain of 15.0 dB and G/T ratio of 10.00 dB\n"
-     ]
-    }
-   ],
-   "source": [
-    "g_over_t = 10 * u.dB\n",
-    "\n",
-    "temperature = 300 * u.K\n",
-    "gain = antenna.gain_from_g_over_t(g_over_t, temperature)\n",
-    "print(f\"The gain is {gain:0.1f} from a {g_over_t:0.1f} G/T ratio at {temperature:0.2f}\")\n",
-    "\n",
-    "gain = 15 * u.dB\n",
-    "temperature = antenna.temperature_from_g_over_t(g_over_t, gain)\n",
-    "print(f\"The temperature is {temperature:0.1f} from a gain of {gain:0.1f} and G/T ratio of {g_over_t:0.2f}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Next we can calculate the loss resulting from axial ratio mismatch between two antennas\n",
     "assuming worst-case orientations of the polarization ellipses (90° apart)."
    ]

--- a/src/spacelink/core/antenna.py
+++ b/src/spacelink/core/antenna.py
@@ -695,7 +695,7 @@ def gain_from_g_over_t(
     g_over_t: DecibelPerKelvin, temperature: Temperature
 ) -> Decibels:
     r"""
-    Gain in dB from the ratio of gain to the noise and temperature.
+    Antenna gain from G/T and system noise temperature
 
     The formula used is:
     G = G/T + 10*log10(T)
@@ -735,7 +735,7 @@ def temperature_from_g_over_t(
     Returns
     -------
     Temperature
-        Temperature in Kelvin.
+        System noise temperature
     """
-    delta_db = gain - g_over_t.value * u.dB
-    return to_linear(delta_db, factor=10) * u.K
+    delta_db = gain - g_over_t
+    return np.power(10, delta_db.value / 10) * u.K

--- a/src/spacelink/core/antenna.py
+++ b/src/spacelink/core/antenna.py
@@ -697,15 +697,12 @@ def gain_from_g_over_t(
     r"""
     Antenna gain from G/T and system noise temperature
 
-    The formula used is:
-    G = G/T + 10*log10(T)
-
     Parameters
     ----------
     g_over_t: DecibelPerKelvin
         Ratio of gain to the noise (G/T in dB/K)
     temperature: Temperature
-        Temperature in Kelvin.
+        System noise temperature
 
     Returns
     -------

--- a/src/spacelink/core/antenna.py
+++ b/src/spacelink/core/antenna.py
@@ -70,7 +70,7 @@ from .units import (
     to_linear,
     safe_negate,
     Temperature,
-    Decibels_over_temperature,
+    DecibelPerKelvin,
 )
 
 
@@ -691,7 +691,9 @@ def _surface_integral(theta: Angle, phi: Angle, values: Dimensionless) -> SolidA
 
 
 @enforce_units
-def gain_from_g_over_t(g_over_t: Decibels_over_temperature, temperature: Temperature) -> Decibels:
+def gain_from_g_over_t(
+    g_over_t: DecibelPerKelvin, temperature: Temperature
+) -> Decibels:
     r"""
     Gain in dB from the ratio of gain to the noise and temperature.
 
@@ -700,7 +702,7 @@ def gain_from_g_over_t(g_over_t: Decibels_over_temperature, temperature: Tempera
 
     Parameters
     ----------
-    g_over_t: Decibels_over_temperature 
+    g_over_t: DecibelPerKelvin
         Ratio of gain to the noise (G/T in dB/K)
     temperature: Temperature
         Temperature in Kelvin.
@@ -713,21 +715,19 @@ def gain_from_g_over_t(g_over_t: Decibels_over_temperature, temperature: Tempera
     if temperature < 0 * u.K:
         raise ValueError("Temperature must be positive")
 
-    # Calculate 10*log10(T)
-    log_temp = to_dB(temperature.value * u.dimensionless, factor=10)
-    
-    # G = G/T + 10*log10(T)
-    return g_over_t + log_temp
+    return g_over_t.value * u.dB + to_dB(temperature / u.K)
 
 
 @enforce_units
-def temperature_from_g_over_t(g_over_t: Decibels_over_temperature, gain: Decibels) -> Temperature:
+def temperature_from_g_over_t(
+    g_over_t: DecibelPerKelvin, gain: Decibels
+) -> Temperature:
     r"""
     Calculate the temperature in Kelvin from ratio of gain to the noise.
 
     Parameters
     ----------
-    g_over_t: Decibels_over_temperature 
+    g_over_t: DecibelPerKelvin
         Ratio of gain to the noise.
     gain: Decibels
         Gain in dB.
@@ -737,5 +737,5 @@ def temperature_from_g_over_t(g_over_t: Decibels_over_temperature, gain: Decibel
     Temperature
         Temperature in Kelvin.
     """
-    delta_db = (gain- g_over_t)
+    delta_db = gain - g_over_t.value * u.dB
     return to_linear(delta_db, factor=10) * u.K

--- a/src/spacelink/core/antenna.py
+++ b/src/spacelink/core/antenna.py
@@ -712,7 +712,8 @@ def gain_from_g_over_t(
     if temperature < 0 * u.K:
         raise ValueError("Temperature must be positive")
 
-    return g_over_t.value * u.dB + to_dB(temperature / u.K)
+    gain = g_over_t + temperature.to(u.dBK)
+    return gain.to(u.dB)
 
 
 @enforce_units
@@ -734,5 +735,4 @@ def temperature_from_g_over_t(
     Temperature
         System noise temperature
     """
-    delta_db = gain - g_over_t
-    return np.power(10, delta_db.value / 10) * u.K
+    return (gain - g_over_t).to(u.K)

--- a/src/spacelink/core/antenna.py
+++ b/src/spacelink/core/antenna.py
@@ -688,6 +688,7 @@ def _surface_integral(theta: Angle, phi: Angle, values: Dimensionless) -> SolidA
     int_phi = scipy.integrate.simpson(integrand, phi, axis=1)
     return scipy.integrate.simpson(int_phi, theta) * u.sr
 
+
 @enforce_units
 def gain_from_g_over_t(g_over_t: Decibels, temperature: Temperature) -> Decibels:
     r"""
@@ -699,7 +700,7 @@ def gain_from_g_over_t(g_over_t: Decibels, temperature: Temperature) -> Decibels
         Ratio of gain to the noise
     temperature: Temperature
         Tin Kelvin.
-    
+
     Returns
     -------
     Decibels
@@ -707,7 +708,7 @@ def gain_from_g_over_t(g_over_t: Decibels, temperature: Temperature) -> Decibels
     """
     if temperature < 0 * u.K:
         raise ValueError("Temperature must be positive")
-    
+
     return g_over_t + to_dB(temperature / u.K)
 
 

--- a/src/spacelink/core/units.py
+++ b/src/spacelink/core/units.py
@@ -82,6 +82,8 @@ if not hasattr(u, "dBm"):  # pragma: no cover
     u.dBm = u.dB(u.mW)
 if not hasattr(u, "dBK"):  # pragma: no cover
     u.dBK = u.dB(u.K)
+if not hasattr(u, "dB_per_K"):  # pragma: no cover
+    u.dB_per_K = u.dB(1 / u.K)
 
 if not hasattr(u, "dimensionless"):  # pragma: no cover
     u.dimensionless = u.dimensionless_unscaled
@@ -90,6 +92,7 @@ Decibels = Annotated[Quantity, u.dB]
 DecibelWatts = Annotated[Quantity, u.dB(u.W)]
 DecibelMilliwatts = Annotated[Quantity, u.dB(u.mW)]
 DecibelKelvins = Annotated[Quantity, u.dB(u.K)]
+DecibelPerKelvin = Annotated[Quantity, u.dB(1 / u.K)]
 Power = Annotated[Quantity, u.W]
 PowerDensity = Annotated[Quantity, u.W / u.Hz]
 Frequency = Annotated[Quantity, u.Hz]

--- a/tests/core/test_antenna.py
+++ b/tests/core/test_antenna.py
@@ -669,15 +669,15 @@ class TestRadiationPatternValidation:
 
 
 def test_gain_from_g_over_t():
-    """ where temp is exectly 1 K """
+    """where temp is exectly 1 K"""
     gain = gain_from_g_over_t(10 * u.dB, 1 * u.K)
     assert_quantity_allclose(gain, 10 * u.dB)
 
-    """ test where temp is greater than 1 K """ 
+    """ test where temp is greater than 1 K """
     gain_100_K = gain_from_g_over_t(10 * u.dB, 100 * u.K)
     assert_quantity_allclose(gain_100_K, 30 * u.dB)
 
-    """ test for negative temperature """ 
+    """ test for negative temperature """
     with pytest.raises(ValueError):
         gain_from_g_over_t(10 * u.dB, -1 * u.K)
 

--- a/tests/core/test_antenna.py
+++ b/tests/core/test_antenna.py
@@ -14,6 +14,8 @@ from spacelink.core.antenna import (
     Handedness,
     RadiationPattern,
     SphericalInterpolator,
+    gain_from_g_over_t,
+    temperature_from_g_over_t,
 )
 from spacelink.core.units import (
     Dimensionless,
@@ -664,3 +666,22 @@ class TestRadiationPatternValidation:
         phi_too_much = np.linspace(0, 2.5 * np.pi, 10) * u.rad
         with pytest.raises(ValueError):
             RadiationPattern(theta, phi_too_much, e_theta, e_phi, rad_efficiency)
+
+
+def test_gain_from_g_over_t():
+    """ where temp is exectly 1 K """
+    gain = gain_from_g_over_t(10 * u.dB, 1 * u.K)
+    assert_quantity_allclose(gain, 10 * u.dB)
+
+    """ test where temp is greater than 1 K """ 
+    gain_100_K = gain_from_g_over_t(10 * u.dB, 100 * u.K)
+    assert_quantity_allclose(gain_100_K, 30 * u.dB)
+
+    """ test for negative temperature """ 
+    with pytest.raises(ValueError):
+        gain_from_g_over_t(10 * u.dB, -1 * u.K)
+
+
+def test_temperature_from_g_over_t():
+    temperature = temperature_from_g_over_t(10 * u.dB, 20 * u.dB)
+    assert_quantity_allclose(temperature, 10 * u.K)

--- a/tests/core/test_antenna.py
+++ b/tests/core/test_antenna.py
@@ -669,7 +669,6 @@ class TestRadiationPatternValidation:
 
 
 def test_gain_from_g_over_t():
-    """Test gain calculation from G/T ratio."""
     # Test where temp is exactly 1 K
     gain = gain_from_g_over_t(10 * u.dB_per_K, 1 * u.K)
     assert_quantity_allclose(gain, 10 * u.dB)
@@ -684,6 +683,6 @@ def test_gain_from_g_over_t():
 
 
 def test_temperature_from_g_over_t():
-    """Test temperature calculation from G/T ratio."""
+    # Test temperature calculation from G/T ratio
     temperature = temperature_from_g_over_t(10 * u.dB_per_K, 20 * u.dB)
     assert_quantity_allclose(temperature, 10 * u.K)

--- a/tests/core/test_antenna.py
+++ b/tests/core/test_antenna.py
@@ -669,19 +669,21 @@ class TestRadiationPatternValidation:
 
 
 def test_gain_from_g_over_t():
-    """where temp is exectly 1 K"""
-    gain = gain_from_g_over_t(10 * u.dB, 1 * u.K)
+    """Test gain calculation from G/T ratio."""
+    # Test where temp is exactly 1 K
+    gain = gain_from_g_over_t(10 * u.dB_per_K, 1 * u.K)
     assert_quantity_allclose(gain, 10 * u.dB)
 
-    """ test where temp is greater than 1 K """
-    gain_100_K = gain_from_g_over_t(10 * u.dB, 100 * u.K)
+    # Test where temp is greater than 1 K
+    gain_100_K = gain_from_g_over_t(10 * u.dB_per_K, 100 * u.K)
     assert_quantity_allclose(gain_100_K, 30 * u.dB)
 
-    """ test for negative temperature """
+    # Test for negative temperature
     with pytest.raises(ValueError):
-        gain_from_g_over_t(10 * u.dB, -1 * u.K)
+        gain_from_g_over_t(10 * u.dB_per_K, -1 * u.K)
 
 
 def test_temperature_from_g_over_t():
-    temperature = temperature_from_g_over_t(10 * u.dB, 20 * u.dB)
+    """Test temperature calculation from G/T ratio."""
+    temperature = temperature_from_g_over_t(10 * u.dB_per_K, 20 * u.dB)
     assert_quantity_allclose(temperature, 10 * u.K)


### PR DESCRIPTION
Added functions temperature_from_g_over_t and  gain_from_g_over_t to calculate temp and gain when the G/T ratio is known.

helper functions #40 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cascade-space-co/spacelink/47)
<!-- Reviewable:end -->
