### PR TITLE
Docs build now fails on warnings

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build documentation
         run: |
-          poetry run sphinx-build -b html docs/source docs/build
+          poetry run sphinx-build --fail-on-warning -b html docs/source docs/build
 
       - name: Check for HTML output
         run: |


### PR DESCRIPTION
sphinx-build just logs a warning when referenced .rst files are missing but doesn't fail. By failing on warnings we avoid building broken docs in the docs-build action without noticing.