### PR TITLE
Test PN acquisition time validation logic

### DIFF
--- a/tests/core/test_ranging.py
+++ b/tests/core/test_ranging.py
@@ -108,6 +108,25 @@ def test_modulation_factor(
     )
 
 
+def test_pn_acquisition_time_invalid_inputs():
+    # success_probability out of bounds
+    with pytest.raises(ValueError):
+        ranging.pn_acquisition_time(
+            30.0 * u.dBHz, 0.0 * u.dimensionless, ranging.PnRangingCode.DSN
+        )
+    with pytest.raises(ValueError):
+        ranging.pn_acquisition_time(
+            30.0 * u.dBHz, 1.0 * u.dimensionless, ranging.PnRangingCode.DSN
+        )
+
+    # invalid code
+    class _BadCode:
+        pass
+
+    with pytest.raises(ValueError):
+        ranging.pn_acquisition_time(30.0 * u.dBHz, 0.5 * u.dimensionless, _BadCode())
+
+
 def test_invalid_modulation():
     """Test that ValueError is raised for invalid modulation type."""
     invalid_modulation = "hogwash"


### PR DESCRIPTION
Adds a test for some validation logic in `ranging.pn_acquisition_time()`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cascade-space-co/spacelink/57)
<!-- Reviewable:end -->
