### PR TITLE
Enforce return value units in tests

### DIFF
--- a/src/spacelink/core/antenna.py
+++ b/src/spacelink/core/antenna.py
@@ -325,7 +325,7 @@ class _ComplexInterpolator:
     @enforce_units
     def __call__(
         self, theta: Angle, phi: Angle, frequency: Frequency | None = None
-    ) -> Dimensionless:
+    ) -> u.Quantity:
         r"""
         Interpolate at the given coordinates.
 

--- a/src/spacelink/core/units.py
+++ b/src/spacelink/core/units.py
@@ -110,7 +110,7 @@ SolidAngle = Annotated[Quantity, u.sr]
 Time = Annotated[Quantity, u.s]
 
 # Module-level flag to enable return unit checking (for tests)
-_RETURN_UNITS_CHECK_STRICT = False
+_RETURN_UNITS_CHECK_ENABLED = False
 
 
 def _extract_annotated_from_hint(hint: Any) -> tuple[type, u.Unit] | None:
@@ -306,7 +306,7 @@ def _validate_return_units(result: Any, ret_hint: Any) -> None:
     ret_hint : Any
         Return type hint
     """
-    if not _RETURN_UNITS_CHECK_STRICT or ret_hint is None:
+    if not _RETURN_UNITS_CHECK_ENABLED or ret_hint is None:
         return
 
     # Try tuple support first

--- a/src/spacelink/core/units.py
+++ b/src/spacelink/core/units.py
@@ -109,6 +109,9 @@ Angle = Annotated[Quantity, u.rad]
 SolidAngle = Annotated[Quantity, u.sr]
 Time = Annotated[Quantity, u.s]
 
+# Module-level flag to enable return unit checking (for tests)
+_RETURN_UNITS_CHECK_STRICT = False
+
 
 def _extract_annotated_from_hint(hint: Any) -> tuple[type, u.Unit] | None:
     """
@@ -224,7 +227,36 @@ def enforce_units(func):
                         f"Parameter '{name}' must be provided as an astropy Quantity, "
                         f"not a raw number."
                     )
-        return func(*bound.args, **bound.kwargs)
+
+        result = func(*bound.args, **bound.kwargs)
+
+        # Check return value units if strict checking is enabled
+        if _RETURN_UNITS_CHECK_STRICT:
+            ret_hint = hints.get("return")
+            annotated_info = _extract_annotated_from_hint(ret_hint)
+
+            if annotated_info is not None:
+                _, expected_unit = annotated_info
+
+                # Allow None only if the return annotation is a union including None
+                if result is None:
+                    origin = get_origin(ret_hint)
+                    if not (
+                        origin in (Union, getattr(types, "UnionType", ()))
+                        and type(None) in get_args(ret_hint)
+                    ):
+                        raise TypeError(
+                            "Return value is None but not annotated as Optional."
+                        )
+                else:
+                    if not isinstance(result, Quantity):
+                        raise TypeError("Return value must be an astropy Quantity.")
+                    if result.unit != expected_unit:
+                        raise u.UnitConversionError(
+                            f"Return unit {result.unit} != annotated {expected_unit}."
+                        )
+
+        return result
 
     return wrapper
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Test configuration and fixtures."""
+
+import pytest
+
+import spacelink.core.units as units
+
+
+@pytest.fixture(autouse=True)
+def _enable_return_units_check():
+    """Enable strict return unit checking during tests."""
+    units._RETURN_UNITS_CHECK_ENABLED = True
+    yield
+    units._RETURN_UNITS_CHECK_ENABLED = False

--- a/tests/core/test_units.py
+++ b/tests/core/test_units.py
@@ -148,163 +148,6 @@ def safe_negate(quantity):
     return (-1) * quantity
 
 
-def test_enforce_units_conversion():
-    """Test that enforce_units decorator properly converts units."""
-
-    @enforce_units
-    def test_angle_function(angle: Angle) -> Angle:
-        """Function that expects angle in radians."""
-        # This function expects the input to be converted to radians
-        # If the decorator works correctly, angle.unit should be u.rad
-        assert angle.unit == u.rad, f"Expected radians, got {angle.unit}"
-        return angle * 2
-
-    @enforce_units
-    def test_frequency_function(freq: Frequency) -> Frequency:
-        """Function that expects frequency in Hz."""
-        # This function expects the input to be converted to Hz
-        assert freq.unit == u.Hz, f"Expected Hz, got {freq.unit}"
-        return freq * 2
-
-    @enforce_units
-    def test_temperature_function(temp: Temperature) -> Temperature:
-        """Function that expects temperature in Kelvin."""
-        # This function expects the input to be converted to Kelvin
-        assert temp.unit == u.K, f"Expected K, got {temp.unit}"
-        return temp + (10 * u.K)
-
-    # Test angle conversion: degrees should be converted to radians
-    input_angle = 180 * u.deg  # 180 degrees = π radians
-    result_angle = test_angle_function(input_angle)
-    expected_radians = np.pi * u.rad
-    assert_quantity_allclose(input_angle.to(u.rad), expected_radians)
-    assert_quantity_allclose(result_angle, 2 * expected_radians)
-
-    # Test frequency conversion: MHz should be converted to Hz
-    input_freq = 1000 * u.MHz  # 1000 MHz = 1e9 Hz
-    result_freq = test_frequency_function(input_freq)
-    expected_hz = 1e9 * u.Hz
-    assert_quantity_allclose(result_freq, 2 * expected_hz)
-
-    # Test temperature conversion: Celsius should be converted to Kelvin
-    input_temp = 0 * u.deg_C  # 0°C = 273.15 K
-    result_temp = test_temperature_function(input_temp)
-    expected_k = 273.15 * u.K
-    assert_quantity_allclose(result_temp, expected_k + (10 * u.K), rtol=1e-10)
-
-
-def test_enforce_units_rejects_incompatible_units():
-    """Test that enforce_units decorator rejects incompatible units."""
-
-    @enforce_units
-    def test_angle_function(angle: Angle) -> Angle:
-        return angle * 2
-
-    # Should raise UnitConversionError for incompatible units
-    with pytest.raises(u.UnitConversionError):
-        test_angle_function(5 * u.m)  # Length instead of angle
-
-    # Should raise TypeError for raw numbers
-    with pytest.raises(TypeError):
-        test_angle_function(45)  # Raw number instead of Quantity
-
-
-def test_enforce_units_optional_parameters():
-    """Test that enforce_units decorator handles optional parameters correctly."""
-
-    @enforce_units
-    def test_optional_frequency(freq: Frequency | None = None) -> str:
-        """Function with optional frequency parameter."""
-        if freq is None:
-            return "no frequency"
-        # Verify the frequency is converted to Hz
-        assert freq.unit == u.Hz
-        return f"frequency: {freq.value} Hz"
-
-    @enforce_units
-    def test_optional_angle(angle: Angle | None = None, scale: float = 1.0) -> str:
-        """Function with optional angle parameter and non-unit parameter."""
-        if angle is None:
-            return "no angle"
-        # Verify the angle is converted to radians
-        assert angle.unit == u.rad
-        return f"angle: {angle.value * scale} rad"
-
-    # Test with None values - should work without enforcement
-    result = test_optional_frequency(None)
-    assert result == "no frequency"
-
-    result = test_optional_frequency()  # Default None
-    assert result == "no frequency"
-
-    # Test with valid Quantity values - should be converted properly
-    result = test_optional_frequency(1000 * u.MHz)
-    assert result == "frequency: 1000000000.0 Hz"
-
-    result = test_optional_angle(180 * u.deg)
-    expected_radians = np.pi
-    assert f"angle: {expected_radians} rad" == result
-
-    # Test with multiple parameters where one is optional
-    result = test_optional_angle(90 * u.deg, scale=2.0)
-    expected_radians = np.pi / 2 * 2.0
-    assert f"angle: {expected_radians} rad" == result
-
-    result = test_optional_angle(None, scale=2.0)
-    assert result == "no angle"
-
-
-def test_enforce_units_optional_parameters_invalid_units():
-    """Test that enforce_units rejects invalid units for optional parameters."""
-
-    @enforce_units
-    def test_optional_frequency(freq: Frequency | None = None) -> str:
-        return "ok"
-
-    # Should raise UnitConversionError for incompatible units
-    with pytest.raises(u.UnitConversionError):
-        test_optional_frequency(5 * u.m)  # Length instead of frequency
-
-    # Should raise TypeError for raw numbers
-    with pytest.raises(TypeError):
-        test_optional_frequency(1000)  # Raw number instead of Quantity
-
-
-def test_enforce_units_multiple_optional_parameters():
-    """Test enforce_units with multiple optional parameters."""
-
-    @enforce_units
-    def test_function(
-        freq: Frequency | None = None,
-        angle: Angle | None = None,
-        temp: Temperature | None = None,
-    ) -> str:
-        results = []
-        if freq is not None:
-            assert freq.unit == u.Hz
-            results.append(f"freq: {freq.value}")
-        if angle is not None:
-            assert angle.unit == u.rad
-            results.append(f"angle: {angle.value}")
-        if temp is not None:
-            assert temp.unit == u.K
-            results.append(f"temp: {temp.value}")
-        return ", ".join(results) if results else "all none"
-
-    # Test all None
-    assert test_function() == "all none"
-
-    # Test mixed values
-    result = test_function(freq=1 * u.GHz, angle=None, temp=300 * u.K)
-    assert "freq: 1000000000.0" in result
-    assert "temp: 300.0" in result
-    assert "angle:" not in result
-
-    # Test temperature conversion (Celsius to Kelvin)
-    result = test_function(temp=0 * u.deg_C)  # 0°C = 273.15 K
-    assert "temp: 273.15" in result
-
-
 def test_custom_units_exist():
     """Test that custom units are added to astropy.units"""
     assert hasattr(u, "dBHz")
@@ -314,175 +157,330 @@ def test_custom_units_exist():
     assert hasattr(u, "dimensionless")
 
 
-def test_enforce_units_return_value_strict_mode():
-    """Test that enforce_units validates return value units in strict mode."""
+class TestEnforceUnitsArgs:
+    """Test enforce_units decorator argument processing."""
 
-    @enforce_units
-    def correct_return_units() -> Frequency:
-        """Function that returns correct units."""
-        return 1000.0 * u.Hz
+    def test_conversion(self):
+        """Test that enforce_units decorator properly converts units."""
 
-    @enforce_units
-    def wrong_return_units() -> Frequency:
-        """Function that returns wrong units."""
-        return 1.0 * u.MHz  # MHz instead of Hz
+        @enforce_units
+        def test_angle_function(angle: Angle) -> Angle:
+            """Function that expects angle in radians."""
+            # This function expects the input to be converted to radians
+            # If the decorator works correctly, angle.unit should be u.rad
+            assert angle.unit == u.rad, f"Expected radians, got {angle.unit}"
+            return angle * 2
 
-    @enforce_units
-    def non_quantity_return() -> Frequency:
-        """Function that returns non-Quantity."""
-        return 1000.0  # Raw number instead of Quantity
+        @enforce_units
+        def test_frequency_function(freq: Frequency) -> Frequency:
+            """Function that expects frequency in Hz."""
+            # This function expects the input to be converted to Hz
+            assert freq.unit == u.Hz, f"Expected Hz, got {freq.unit}"
+            return freq * 2
 
-    @enforce_units
-    def optional_return_none() -> Frequency | None:
-        """Function that can return None."""
-        return None
+        @enforce_units
+        def test_temperature_function(temp: Temperature) -> Temperature:
+            """Function that expects temperature in Kelvin."""
+            # This function expects the input to be converted to K
+            assert temp.unit == u.K, f"Expected K, got {temp.unit}"
+            return temp * 2
 
-    @enforce_units
-    def optional_return_wrong_none() -> Frequency:
-        """Function that returns None but not annotated as optional."""
-        return None
+        # Test angle conversion
+        result = test_angle_function(np.pi / 4 * u.rad)
+        assert_quantity_allclose(result, np.pi / 2 * u.rad)
 
-    # Test correct return units - should pass
-    result = correct_return_units()
-    assert result == 1000.0 * u.Hz
+        # Test conversion from degrees to radians
+        result = test_angle_function(45 * u.deg)  # Should be converted to radians
+        assert_quantity_allclose(result, np.pi / 2 * u.rad)
 
-    # Test wrong return units - should fail in strict mode
-    with pytest.raises(u.UnitConversionError):
-        wrong_return_units()
+        # Test frequency conversion
+        result = test_frequency_function(1000 * u.Hz)
+        assert_quantity_allclose(result, 2000 * u.Hz)
 
-    # Test non-Quantity return - should fail
-    with pytest.raises(TypeError):
-        non_quantity_return()
+        # Test conversion from MHz to Hz
+        result = test_frequency_function(1 * u.MHz)
+        assert_quantity_allclose(result, 2000000 * u.Hz)
 
-    # Test optional return None - should pass
-    result = optional_return_none()
-    assert result is None
+        # Test temperature conversion (identity for Kelvin)
+        result = test_temperature_function(300 * u.K)
+        assert_quantity_allclose(result, 600 * u.K)
 
-    # Test non-optional return None - should fail
-    with pytest.raises(TypeError):
-        optional_return_wrong_none()
+        # Test temperature conversion from Celsius to Kelvin
+        result = test_temperature_function(0 * u.deg_C)  # 0°C = 273.15 K
+        assert_quantity_allclose(result, 2 * 273.15 * u.K)
+
+    def test_rejects_incompatible_units(self):
+        """Test that enforce_units decorator rejects incompatible units."""
+
+        @enforce_units
+        def test_angle_function(angle: Angle) -> Angle:
+            return angle * 2
+
+        # Should raise UnitConversionError for incompatible units
+        with pytest.raises(u.UnitConversionError):
+            test_angle_function(5 * u.m)  # Length instead of angle
+
+        # Should raise TypeError for raw numbers
+        with pytest.raises(TypeError):
+            test_angle_function(45)  # Raw number instead of Quantity
+
+    def test_optional_parameters(self):
+        """Test that enforce_units decorator handles optional parameters correctly."""
+
+        @enforce_units
+        def test_optional_frequency(freq: Frequency | None = None) -> str:
+            """Function with optional frequency parameter."""
+            if freq is None:
+                return "no frequency"
+            else:
+                return f"frequency: {freq.value} Hz"
+
+        @enforce_units
+        def test_optional_angle(angle: Angle | None = None, scale: float = 1.0) -> str:
+            """Function with optional angle parameter and non-unit parameter."""
+            results = []
+            if angle is not None:
+                results.append(f"angle: {angle.value}")
+            if scale != 1.0:
+                results.append(f"scale: {scale}")
+            return ", ".join(results) if results else "defaults"
+
+        # Test with None values
+        assert test_optional_frequency() == "no frequency"
+        assert test_optional_frequency(None) == "no frequency"
+        assert test_optional_angle() == "defaults"
+        assert test_optional_angle(None) == "defaults"
+
+        # Test with actual values
+        result = test_optional_frequency(1000 * u.Hz)
+        assert result == "frequency: 1000.0 Hz"
+
+        # Test angle conversion with optional
+        result = test_optional_angle(45 * u.deg)  # Should convert to radians
+        expected_rad = (45 * u.deg).to(u.rad).value
+        assert f"angle: {expected_rad}" in result
+
+        # Test with non-unit parameter
+        result = test_optional_angle(scale=2.0)
+        assert "scale: 2.0" in result
+
+    def test_optional_parameters_invalid_units(self):
+        """Test that enforce_units rejects invalid units for optional parameters."""
+
+        @enforce_units
+        def test_optional_frequency(freq: Frequency | None = None) -> str:
+            return "ok"
+
+        # Should raise UnitConversionError for incompatible units
+        with pytest.raises(u.UnitConversionError):
+            test_optional_frequency(5 * u.m)  # Length instead of frequency
+
+        # Should raise TypeError for raw numbers
+        with pytest.raises(TypeError):
+            test_optional_frequency(1000)  # Raw number instead of Quantity
+
+    def test_multiple_optional_parameters(self):
+        """Test enforce_units with multiple optional parameters."""
+
+        @enforce_units
+        def test_function(
+            freq: Frequency | None = None,
+            angle: Angle | None = None,
+            temp: Temperature | None = None,
+        ) -> str:
+            """Function with multiple optional unit parameters."""
+            results = []
+            if freq is not None:
+                results.append(f"freq: {freq.value}")
+            if angle is not None:
+                results.append(f"angle: {angle.value}")
+            if temp is not None:
+                results.append(f"temp: {temp.value}")
+            return ", ".join(results) if results else "all none"
+
+        # Test all None
+        assert test_function() == "all none"
+
+        # Test mixed values
+        result = test_function(freq=1 * u.GHz, angle=None, temp=300 * u.K)
+        assert "freq: 1000000000.0" in result
+        assert "temp: 300.0" in result
+        assert "angle:" not in result
+
+        # Test temperature conversion (Celsius to Kelvin)
+        result = test_function(temp=0 * u.deg_C)  # 0°C = 273.15 K
+        assert "temp: 273.15" in result
 
 
-@pytest.mark.parametrize(
-    "return_type, wrong_value, expected_value",
-    [
-        ("single", lambda: 1.0 * u.MHz, 1.0 * u.MHz),
-        ("tuple", lambda: (1.0 * u.MHz, 10.0 * u.W), (1.0 * u.MHz, 10.0 * u.W)),
-    ],
-)
-def test_enforce_units_return_value_disabled(return_type, wrong_value, expected_value):
-    """Test that return value checking can be disabled."""
+class TestEnforceUnitsReturns:
+    """Test enforce_units decorator return value validation."""
 
-    if return_type == "single":
+    def test_return_value_strict_mode(self):
+        """Test that enforce_units validates return value units in strict mode."""
+
+        @enforce_units
+        def correct_return_units() -> Frequency:
+            """Function that returns correct units."""
+            return 1000.0 * u.Hz
 
         @enforce_units
         def wrong_return_units() -> Frequency:
             """Function that returns wrong units."""
-            return wrong_value()
-    else:  # tuple
+            return 1.0 * u.MHz  # MHz instead of Hz
 
         @enforce_units
-        def wrong_return_units() -> tuple[Frequency, Power]:
+        def non_quantity_return() -> Frequency:
+            """Function that returns non-Quantity."""
+            return 1000.0  # Raw number instead of Quantity
+
+        @enforce_units
+        def optional_return_none() -> Frequency | None:
+            """Function that can return None."""
+            return None
+
+        @enforce_units
+        def optional_return_wrong_none() -> Frequency:
+            """Function that returns None but not annotated as optional."""
+            return None
+
+        # Test correct return units - should pass
+        result = correct_return_units()
+        assert result == 1000.0 * u.Hz
+
+        # Test wrong return units - should fail in strict mode
+        with pytest.raises(u.UnitConversionError):
+            wrong_return_units()
+
+        # Test non-Quantity return - should fail
+        with pytest.raises(TypeError):
+            non_quantity_return()
+
+        # Test optional return None - should pass
+        result = optional_return_none()
+        assert result is None
+
+        # Test non-optional return None - should fail
+        with pytest.raises(TypeError):
+            optional_return_wrong_none()
+
+    def test_return_value_complex_types(self):
+        """Test return value checking with complex unit types."""
+
+        @enforce_units
+        def return_decibels() -> Decibels:
+            """Function that returns decibels."""
+            return 10.0 * u.dB
+
+        @enforce_units
+        def return_wrong_decibels() -> Decibels:
+            """Function that returns wrong decibel unit."""
+            return 10.0 * u.dBW  # dBW instead of dB
+
+        @enforce_units
+        def return_dimensionless() -> Dimensionless:
+            """Function that returns dimensionless quantity."""
+            return 1.5 * u.dimensionless
+
+        # Test correct decibel return
+        result = return_decibels()
+        assert result == 10.0 * u.dB
+
+        # Test wrong decibel type - should fail
+        with pytest.raises(u.UnitConversionError):
+            return_wrong_decibels()
+
+        # Test dimensionless return
+        result = return_dimensionless()
+        assert result == 1.5 * u.dimensionless
+
+    @pytest.mark.parametrize(
+        "return_type, wrong_value, expected_value",
+        [
+            ("single", lambda: 1.0 * u.MHz, 1.0 * u.MHz),
+            ("tuple", lambda: (1.0 * u.MHz, 10.0 * u.W), (1.0 * u.MHz, 10.0 * u.W)),
+        ],
+    )
+    def test_return_value_disabled(self, return_type, wrong_value, expected_value):
+        """Test that return value checking can be disabled."""
+
+        if return_type == "single":
+
+            @enforce_units
+            def wrong_return_units() -> Frequency:
+                """Function that returns wrong units."""
+                return wrong_value()
+        else:  # tuple
+
+            @enforce_units
+            def wrong_return_units() -> tuple[Frequency, Power]:
+                """Function that returns wrong units in tuple."""
+                return wrong_value()
+
+        # Temporarily disable strict checking
+        original_value = units._RETURN_UNITS_CHECK_STRICT
+        try:
+            units._RETURN_UNITS_CHECK_STRICT = False
+
+            # Should not raise when checking is disabled
+            result = wrong_return_units()
+            assert result == expected_value
+
+        finally:
+            units._RETURN_UNITS_CHECK_STRICT = original_value
+
+    def test_tuple_return_values(self):
+        """Test that enforce_units validates tuple return values correctly."""
+
+        @enforce_units
+        def correct_tuple() -> tuple[Frequency, Power]:
+            """Function that returns correct tuple units."""
+            return 1000.0 * u.Hz, 10.0 * u.W
+
+        @enforce_units
+        def wrong_tuple_units() -> tuple[Frequency, Power]:
             """Function that returns wrong units in tuple."""
-            return wrong_value()
+            return 1.0 * u.MHz, 10.0 * u.W  # MHz instead of Hz
 
-    # Temporarily disable strict checking
-    original_value = units._RETURN_UNITS_CHECK_STRICT
-    try:
-        units._RETURN_UNITS_CHECK_STRICT = False
+        @enforce_units
+        def wrong_tuple_length() -> tuple[Frequency, Power]:
+            """Function that returns wrong tuple length."""
+            return (1000.0 * u.Hz,)  # Missing second element
 
-        # Should not raise when checking is disabled
-        result = wrong_return_units()
-        assert result == expected_value
+        @enforce_units
+        def mixed_tuple() -> tuple[str, Frequency, int]:
+            """Function with mixed annotated and non-annotated tuple elements."""
+            return "hello", 1000.0 * u.Hz, 42
 
-    finally:
-        units._RETURN_UNITS_CHECK_STRICT = original_value
+        @enforce_units
+        def wrong_mixed_tuple() -> tuple[str, Frequency, int]:
+            """Function with wrong units in mixed tuple."""
+            return "hello", 1.0 * u.MHz, 42  # Wrong frequency unit
 
+        @enforce_units
+        def non_quantity_in_tuple() -> tuple[Frequency, Power]:
+            """Function that returns non-Quantity in tuple."""
+            return 1000.0, 10.0 * u.W  # Raw number instead of Quantity
 
-def test_enforce_units_return_value_complex_types():
-    """Test return value checking with complex unit types."""
+        # Test correct tuple - should pass
+        result = correct_tuple()
+        assert result == (1000.0 * u.Hz, 10.0 * u.W)
 
-    @enforce_units
-    def return_decibels() -> Decibels:
-        """Function that returns decibels."""
-        return 10.0 * u.dB
+        # Test wrong units in tuple - should fail
+        with pytest.raises(u.UnitConversionError):
+            wrong_tuple_units()
 
-    @enforce_units
-    def return_wrong_decibels() -> Decibels:
-        """Function that returns wrong decibel unit."""
-        return 10.0 * u.dBW  # dBW instead of dB
+        # Test wrong tuple length - should fail
+        with pytest.raises(TypeError):
+            wrong_tuple_length()
 
-    @enforce_units
-    def return_dimensionless() -> Dimensionless:
-        """Function that returns dimensionless quantity."""
-        return 1.5 * u.dimensionless
+        # Test mixed tuple with correct units - should pass
+        result = mixed_tuple()
+        assert result == ("hello", 1000.0 * u.Hz, 42)
 
-    # Test correct decibel return
-    result = return_decibels()
-    assert result == 10.0 * u.dB
+        # Test mixed tuple with wrong units - should fail
+        with pytest.raises(u.UnitConversionError):
+            wrong_mixed_tuple()
 
-    # Test wrong decibel type - should fail
-    with pytest.raises(u.UnitConversionError):
-        return_wrong_decibels()
-
-    # Test dimensionless return
-    result = return_dimensionless()
-    assert result == 1.5 * u.dimensionless
-
-
-def test_enforce_units_tuple_return_values():
-    """Test that enforce_units validates tuple return values correctly."""
-
-    @enforce_units
-    def correct_tuple() -> tuple[Frequency, Power]:
-        """Function that returns correct tuple units."""
-        return 1000.0 * u.Hz, 10.0 * u.W
-
-    @enforce_units
-    def wrong_tuple_units() -> tuple[Frequency, Power]:
-        """Function that returns wrong units in tuple."""
-        return 1.0 * u.MHz, 10.0 * u.W  # MHz instead of Hz
-
-    @enforce_units
-    def wrong_tuple_length() -> tuple[Frequency, Power]:
-        """Function that returns wrong tuple length."""
-        return (1000.0 * u.Hz,)  # Missing second element
-
-    @enforce_units
-    def mixed_tuple() -> tuple[str, Frequency, int]:
-        """Function with mixed annotated and non-annotated tuple elements."""
-        return "hello", 1000.0 * u.Hz, 42
-
-    @enforce_units
-    def wrong_mixed_tuple() -> tuple[str, Frequency, int]:
-        """Function with wrong units in mixed tuple."""
-        return "hello", 1.0 * u.MHz, 42  # Wrong frequency unit
-
-    @enforce_units
-    def non_quantity_in_tuple() -> tuple[Frequency, Power]:
-        """Function that returns non-Quantity in tuple."""
-        return 1000.0, 10.0 * u.W  # Raw number instead of Quantity
-
-    # Test correct tuple - should pass
-    result = correct_tuple()
-    assert result == (1000.0 * u.Hz, 10.0 * u.W)
-
-    # Test wrong units in tuple - should fail
-    with pytest.raises(u.UnitConversionError):
-        wrong_tuple_units()
-
-    # Test wrong tuple length - should fail
-    with pytest.raises(TypeError):
-        wrong_tuple_length()
-
-    # Test mixed tuple with correct units - should pass
-    result = mixed_tuple()
-    assert result == ("hello", 1000.0 * u.Hz, 42)
-
-    # Test mixed tuple with wrong units - should fail
-    with pytest.raises(u.UnitConversionError):
-        wrong_mixed_tuple()
-
-    # Test non-Quantity in tuple - should fail
-    with pytest.raises(TypeError):
-        non_quantity_in_tuple()
+        # Test non-Quantity in tuple - should fail
+        with pytest.raises(TypeError):
+            non_quantity_in_tuple()

--- a/tests/core/test_units.py
+++ b/tests/core/test_units.py
@@ -315,8 +315,8 @@ class TestEnforceUnitsArgs:
 class TestEnforceUnitsReturns:
     """Test enforce_units decorator return value validation."""
 
-    def test_return_value_strict_mode(self):
-        """Test that enforce_units validates return value units in strict mode."""
+    def test_return_value_checking_mode(self):
+        """Test that enforce_units validates return value units."""
 
         @enforce_units
         def correct_return_units() -> Frequency:
@@ -347,7 +347,7 @@ class TestEnforceUnitsReturns:
         result = correct_return_units()
         assert result == 1000.0 * u.Hz
 
-        # Test wrong return units - should fail in strict mode
+        # Test wrong return units - should fail
         with pytest.raises(u.UnitConversionError):
             wrong_return_units()
 
@@ -416,17 +416,17 @@ class TestEnforceUnitsReturns:
                 """Function that returns wrong units in tuple."""
                 return wrong_value()
 
-        # Temporarily disable strict checking
-        original_value = units._RETURN_UNITS_CHECK_STRICT
+        # Temporarily disable checking
+        original_value = units._RETURN_UNITS_CHECK_ENABLED
         try:
-            units._RETURN_UNITS_CHECK_STRICT = False
+            units._RETURN_UNITS_CHECK_ENABLED = False
 
             # Should not raise when checking is disabled
             result = wrong_return_units()
             assert result == expected_value
 
         finally:
-            units._RETURN_UNITS_CHECK_STRICT = original_value
+            units._RETURN_UNITS_CHECK_ENABLED = original_value
 
     def test_tuple_return_values(self):
         """Test that enforce_units validates tuple return values correctly."""

--- a/tests/core/test_units.py
+++ b/tests/core/test_units.py
@@ -8,6 +8,8 @@ from astropy.tests.helper import assert_quantity_allclose
 from spacelink.core import units
 from spacelink.core.units import (
     Angle,
+    Decibels,
+    Dimensionless,
     Frequency,
     Temperature,
     enforce_units,
@@ -309,3 +311,104 @@ def test_custom_units_exist():
     assert hasattr(u, "dBm")
     assert hasattr(u, "dBK")
     assert hasattr(u, "dimensionless")
+
+
+def test_enforce_units_return_value_strict_mode():
+    """Test that enforce_units validates return value units in strict mode."""
+
+    @enforce_units
+    def correct_return_units() -> Frequency:
+        """Function that returns correct units."""
+        return 1000.0 * u.Hz
+
+    @enforce_units
+    def wrong_return_units() -> Frequency:
+        """Function that returns wrong units."""
+        return 1.0 * u.MHz  # MHz instead of Hz
+
+    @enforce_units
+    def non_quantity_return() -> Frequency:
+        """Function that returns non-Quantity."""
+        return 1000.0  # Raw number instead of Quantity
+
+    @enforce_units
+    def optional_return_none() -> Frequency | None:
+        """Function that can return None."""
+        return None
+
+    @enforce_units
+    def optional_return_wrong_none() -> Frequency:
+        """Function that returns None but not annotated as optional."""
+        return None
+
+    # Test correct return units - should pass
+    result = correct_return_units()
+    assert result == 1000.0 * u.Hz
+
+    # Test wrong return units - should fail in strict mode
+    with pytest.raises(u.UnitConversionError):
+        wrong_return_units()
+
+    # Test non-Quantity return - should fail
+    with pytest.raises(TypeError):
+        non_quantity_return()
+
+    # Test optional return None - should pass
+    result = optional_return_none()
+    assert result is None
+
+    # Test non-optional return None - should fail
+    with pytest.raises(TypeError):
+        optional_return_wrong_none()
+
+
+def test_enforce_units_return_value_disabled():
+    """Test that return value checking can be disabled."""
+
+    @enforce_units
+    def wrong_return_units() -> Frequency:
+        """Function that returns wrong units."""
+        return 1.0 * u.MHz  # MHz instead of Hz
+
+    # Temporarily disable strict checking
+    original_value = units._RETURN_UNITS_CHECK_STRICT
+    try:
+        units._RETURN_UNITS_CHECK_STRICT = False
+
+        # Should not raise when checking is disabled
+        result = wrong_return_units()
+        assert result == 1.0 * u.MHz
+
+    finally:
+        units._RETURN_UNITS_CHECK_STRICT = original_value
+
+
+def test_enforce_units_return_value_complex_types():
+    """Test return value checking with complex unit types."""
+
+    @enforce_units
+    def return_decibels() -> Decibels:
+        """Function that returns decibels."""
+        return 10.0 * u.dB
+
+    @enforce_units
+    def return_wrong_decibels() -> Decibels:
+        """Function that returns wrong decibel unit."""
+        return 10.0 * u.dBW  # dBW instead of dB
+
+    @enforce_units
+    def return_dimensionless() -> Dimensionless:
+        """Function that returns dimensionless quantity."""
+        return 1.5 * u.dimensionless
+
+    # Test correct decibel return
+    result = return_decibels()
+    assert result == 10.0 * u.dB
+
+    # Test wrong decibel type - should fail
+    with pytest.raises(u.UnitConversionError):
+        return_wrong_decibels()
+
+    # Test dimensionless return
+    result = return_dimensionless()
+    assert result == 1.5 * u.dimensionless

--- a/tests/core/test_units.py
+++ b/tests/core/test_units.py
@@ -11,6 +11,7 @@ from spacelink.core.units import (
     Decibels,
     Dimensionless,
     Frequency,
+    Power,
     Temperature,
     enforce_units,
     frequency,
@@ -204,7 +205,7 @@ def test_enforce_units_rejects_incompatible_units():
         test_angle_function(5 * u.m)  # Length instead of angle
 
     # Should raise TypeError for raw numbers
-    with pytest.raises(TypeError, match="must be provided as an astropy Quantity"):
+    with pytest.raises(TypeError):
         test_angle_function(45)  # Raw number instead of Quantity
 
 
@@ -265,7 +266,7 @@ def test_enforce_units_optional_parameters_invalid_units():
         test_optional_frequency(5 * u.m)  # Length instead of frequency
 
     # Should raise TypeError for raw numbers
-    with pytest.raises(TypeError, match="must be provided as an astropy Quantity"):
+    with pytest.raises(TypeError):
         test_optional_frequency(1000)  # Raw number instead of Quantity
 
 
@@ -362,13 +363,28 @@ def test_enforce_units_return_value_strict_mode():
         optional_return_wrong_none()
 
 
-def test_enforce_units_return_value_disabled():
+@pytest.mark.parametrize(
+    "return_type, wrong_value, expected_value",
+    [
+        ("single", lambda: 1.0 * u.MHz, 1.0 * u.MHz),
+        ("tuple", lambda: (1.0 * u.MHz, 10.0 * u.W), (1.0 * u.MHz, 10.0 * u.W)),
+    ],
+)
+def test_enforce_units_return_value_disabled(return_type, wrong_value, expected_value):
     """Test that return value checking can be disabled."""
 
-    @enforce_units
-    def wrong_return_units() -> Frequency:
-        """Function that returns wrong units."""
-        return 1.0 * u.MHz  # MHz instead of Hz
+    if return_type == "single":
+
+        @enforce_units
+        def wrong_return_units() -> Frequency:
+            """Function that returns wrong units."""
+            return wrong_value()
+    else:  # tuple
+
+        @enforce_units
+        def wrong_return_units() -> tuple[Frequency, Power]:
+            """Function that returns wrong units in tuple."""
+            return wrong_value()
 
     # Temporarily disable strict checking
     original_value = units._RETURN_UNITS_CHECK_STRICT
@@ -377,7 +393,7 @@ def test_enforce_units_return_value_disabled():
 
         # Should not raise when checking is disabled
         result = wrong_return_units()
-        assert result == 1.0 * u.MHz
+        assert result == expected_value
 
     finally:
         units._RETURN_UNITS_CHECK_STRICT = original_value
@@ -412,3 +428,61 @@ def test_enforce_units_return_value_complex_types():
     # Test dimensionless return
     result = return_dimensionless()
     assert result == 1.5 * u.dimensionless
+
+
+def test_enforce_units_tuple_return_values():
+    """Test that enforce_units validates tuple return values correctly."""
+
+    @enforce_units
+    def correct_tuple() -> tuple[Frequency, Power]:
+        """Function that returns correct tuple units."""
+        return 1000.0 * u.Hz, 10.0 * u.W
+
+    @enforce_units
+    def wrong_tuple_units() -> tuple[Frequency, Power]:
+        """Function that returns wrong units in tuple."""
+        return 1.0 * u.MHz, 10.0 * u.W  # MHz instead of Hz
+
+    @enforce_units
+    def wrong_tuple_length() -> tuple[Frequency, Power]:
+        """Function that returns wrong tuple length."""
+        return (1000.0 * u.Hz,)  # Missing second element
+
+    @enforce_units
+    def mixed_tuple() -> tuple[str, Frequency, int]:
+        """Function with mixed annotated and non-annotated tuple elements."""
+        return "hello", 1000.0 * u.Hz, 42
+
+    @enforce_units
+    def wrong_mixed_tuple() -> tuple[str, Frequency, int]:
+        """Function with wrong units in mixed tuple."""
+        return "hello", 1.0 * u.MHz, 42  # Wrong frequency unit
+
+    @enforce_units
+    def non_quantity_in_tuple() -> tuple[Frequency, Power]:
+        """Function that returns non-Quantity in tuple."""
+        return 1000.0, 10.0 * u.W  # Raw number instead of Quantity
+
+    # Test correct tuple - should pass
+    result = correct_tuple()
+    assert result == (1000.0 * u.Hz, 10.0 * u.W)
+
+    # Test wrong units in tuple - should fail
+    with pytest.raises(u.UnitConversionError):
+        wrong_tuple_units()
+
+    # Test wrong tuple length - should fail
+    with pytest.raises(TypeError):
+        wrong_tuple_length()
+
+    # Test mixed tuple with correct units - should pass
+    result = mixed_tuple()
+    assert result == ("hello", 1000.0 * u.Hz, 42)
+
+    # Test mixed tuple with wrong units - should fail
+    with pytest.raises(u.UnitConversionError):
+        wrong_mixed_tuple()
+
+    # Test non-Quantity in tuple - should fail
+    with pytest.raises(TypeError):
+        non_quantity_in_tuple()


### PR DESCRIPTION
Adds enforcement of return value units to the `enforce_units` decorator. This feature is disabled by default for production and enabled when unit tests run. The intent is to automate checking of return value units so any mismatch with the return type annotation is caught during development. Single return values and tuples of annotated quantities are both supported.