### PR TITLE
Interpolate radiation patterns in linear scale

### DIFF
--- a/src/spacelink/core/antenna.py
+++ b/src/spacelink/core/antenna.py
@@ -214,7 +214,7 @@ class Polarization:
 
 
 class _ComplexInterpolator:
-    """Interpolates complex values using log-magnitude and unit-phase components."""
+    """Interpolates complex values over a spherical coordinate system."""
 
     @enforce_units
     def __init__(
@@ -237,9 +237,8 @@ class _ComplexInterpolator:
         frequency: Frequency | None
             Optional 1D array of strictly increasing frequencies with shape (K,).
         values: Quantity
-            Complex array of values to interpolate. This should be in linear-scale (not
-            log-scale like u.dB). Shape is ``(N, M)`` if ``frequency`` is None,
-            otherwise ``(N, M, K)``.
+            Complex array of values to interpolate. Shape is ``(N, M)`` if ``frequency``
+            is None, otherwise ``(N, M, K)``.
         """
         self.unit = values.unit
         values = values.value

--- a/tests/core/test_antenna.py
+++ b/tests/core/test_antenna.py
@@ -23,7 +23,6 @@ from spacelink.core.units import (
     Dimensionless,
     Frequency,
     Length,
-    to_dB,
     to_linear,
 )
 
@@ -191,143 +190,123 @@ class TestPolarization:
 class TestComplexInterpolator:
     """Tests for the ComplexInterpolator class."""
 
-    def test_interpolation(self):
-        N = 80
-        M = 120
-        downsample = 2
-        periods = 2  # Number of periods in phi
-        peak_gain = 40.0  # Gain varies between ± this value in dBi
-
-        theta = np.linspace(0, np.pi, N) * u.rad
+    def test_exactness_at_grid_nodes(self):
+        """Test that interpolation is exact at the provided grid points."""
+        N, M = 9, 13
+        theta = np.linspace(0.1, np.pi - 0.1, N) * u.rad
         phi = np.linspace(0, 2 * np.pi, M, endpoint=False) * u.rad
 
-        gain_db_expected = (
-            peak_gain
-            * np.sin(theta.value)[:, np.newaxis]  # Taper to 0 dB at poles
-            * np.sin(periods * phi.value)
-            * u.dB
-        )
+        # Use random complex values to ensure we're not relying on special structure
+        np.random.seed(42)
+        values = (np.random.randn(N, M) + 1j * np.random.randn(N, M)) * u.dimensionless
 
-        theta_decim = np.linspace(0, np.pi, N // downsample) * u.rad
-        phi_decim = np.linspace(0, 2 * np.pi, M // downsample, endpoint=False) * u.rad
-        gain_decim_db = (
-            peak_gain
-            * np.sin(theta_decim.value)[:, np.newaxis]  # Taper to 0 dB at poles
-            * np.sin(periods * phi_decim.value)
-            * u.dB
-        )
-        gain_decim = to_linear(gain_decim_db)
+        interpolator = _ComplexInterpolator(theta, phi, None, values)
 
-        interpolator = _ComplexInterpolator(theta_decim, phi_decim, None, gain_decim)
-
+        # Query exactly at grid points
         result = interpolator(theta[:, np.newaxis], phi)
 
-        assert_quantity_allclose(to_dB(result), gain_db_expected, atol=0.3 * u.dB)
+        # Should be exact (within machine precision)
+        assert_quantity_allclose(result, values, atol=1e-12 * u.dimensionless)
 
-    def test_subset_sphere_interpolation(self):
-        N = 80
-        M = 100
-        downsample = 2
-        periods = 2  # Number of periods in phi
-        peak_gain = 40.0  # Gain varies between ± this value in dBi
-
-        # Create subset of sphere: theta from 30° to 120°, phi from 45° to 270°
-        theta = np.linspace(np.pi / 6, 2 * np.pi / 3, N) * u.rad
-        phi = np.linspace(np.pi / 4, 3 * np.pi / 2, M, endpoint=False) * u.rad
-
-        gain_db = (
-            peak_gain
-            * np.sin(theta.value)[:, np.newaxis]
-            * np.sin(periods * phi.value)
-            * u.dB
-        )
-        gain = to_linear(gain_db)
-
-        interpolator = _ComplexInterpolator(
-            theta[::downsample],
-            phi[::downsample],
-            None,
-            gain[::downsample, ::downsample],
-        )
-
-        result = interpolator(
-            theta[:-downsample, np.newaxis],
-            phi[:-downsample],
-        )
-        assert_quantity_allclose(
-            to_dB(result),
-            gain_db[:-downsample, :-downsample],
-            atol=0.2 * u.dB,
-        )
-
-    def test_frequency_dependent_interpolation(self):
-        """Test 3D interpolation over theta, phi, and frequency."""
-        N = 40
-        M = 48
-        K = 10
-        downsample = 2
-        theta = np.linspace(0, np.pi, N) * u.rad
+    def test_phi_periodicity_and_rotation_invariance(self):
+        """Test φ modulo invariance and rotation invariance."""
+        N, M = 12, 16
+        theta = np.linspace(0.1, np.pi - 0.1, N) * u.rad
         phi = np.linspace(0, 2 * np.pi, M, endpoint=False) * u.rad
-        frequency = (np.arange(K) + 1) * u.GHz
 
-        # Amplitude scales with frequency, phase rotates with frequency
-        theta_grid, phi_grid, freq_grid = np.meshgrid(
-            theta, phi, frequency, indexing="ij"
-        )
-        amplitude = freq_grid.to_value(u.GHz) * (1 + np.sin(theta_grid).value)
-        phase = phi_grid.value + 0.5 * freq_grid.value
-        values = amplitude * np.exp(1j * phase) * u.dimensionless
+        np.random.seed(123)
+        values = (np.random.randn(N, M) + 1j * np.random.randn(N, M)) * u.dimensionless
 
-        interpolator = _ComplexInterpolator(
-            theta[::downsample],
-            phi[::downsample],
-            frequency[::downsample],
-            values[::downsample, ::downsample, ::downsample],
-        )
+        interpolator = _ComplexInterpolator(theta, phi, None, values)
 
-        result = interpolator(
-            theta[:-downsample, np.newaxis, np.newaxis],
-            phi[:, np.newaxis],
-            frequency[:-downsample],
+        # Test φ modulo invariance: f(θ, φ) == f(θ, φ + 2π)
+        result1 = interpolator(theta[:, np.newaxis], phi)
+        result2 = interpolator(theta[:, np.newaxis], phi + 2 * np.pi * u.rad)
+        assert_quantity_allclose(result1, result2, atol=1e-12 * u.dimensionless)
+
+        # Test φ rotation invariance: shifting grid and data should give same results
+        shift = 3
+        phi_shifted = np.roll(phi.value, shift) * u.rad
+        values_shifted = np.roll(values.value, shift, axis=1) * u.dimensionless
+        interpolator_shifted = _ComplexInterpolator(
+            theta, phi_shifted, None, values_shifted
         )
 
+        # Test at a different set of points to avoid testing only at grid nodes
+        eval_theta = np.linspace(0.2, np.pi - 0.2, 8) * u.rad
+        eval_phi = np.linspace(0.1, 2 * np.pi - 0.1, 10) * u.rad
+        result_orig = interpolator(eval_theta[:, np.newaxis], eval_phi)
+        result_shifted = interpolator_shifted(eval_theta[:, np.newaxis], eval_phi)
         assert_quantity_allclose(
-            result, values[:-downsample, :, :-downsample], rtol=0.2
+            result_orig, result_shifted, atol=1e-12 * u.dimensionless
         )
 
-    def test_with_zeros(self):
-        """Test interpolation when input contains zeros (should use floor value)."""
-        unit = u.K  # Arbitrary unit
-        floor = 2.847e-12 * unit
-        theta = np.linspace(0, np.pi, 20) * u.rad
-        phi = np.linspace(0, 2 * np.pi, 30, endpoint=False) * u.rad
-        theta_grid, phi_grid = np.meshgrid(theta, phi, indexing="ij")
+    def test_complex_equivariance_properties(self):
+        """Test scaling and conjugation equivariance properties."""
+        N, M = 8, 12
+        theta = np.linspace(0.2, np.pi - 0.2, N) * u.rad
+        phi = np.linspace(0, 2 * np.pi, M, endpoint=False) * u.rad
 
-        # Pattern with zeros at theta > π/2
-        values = (
-            np.where(
-                theta_grid.value < np.pi / 2,
-                np.sin(theta_grid.value) * np.exp(1j * phi_grid.value),
-                0,
-            )
-            * unit
+        np.random.seed(456)
+        values = (np.random.randn(N, M) + 1j * np.random.randn(N, M)) * u.dimensionless
+
+        # Test complex scaling: Interp(c * V) == c * Interp(V)
+        c = 1.2 - 0.7j
+        interpolator_orig = _ComplexInterpolator(theta, phi, None, values)
+        interpolator_scaled = _ComplexInterpolator(theta, phi, None, c * values)
+
+        test_theta = np.linspace(0.3, np.pi - 0.3, 5) * u.rad
+        test_phi = np.linspace(0.1, 2 * np.pi - 0.1, 7) * u.rad
+
+        result_scaled = interpolator_scaled(test_theta[:, np.newaxis], test_phi)
+        expected_scaled = c * interpolator_orig(test_theta[:, np.newaxis], test_phi)
+        assert_quantity_allclose(
+            result_scaled, expected_scaled, atol=1e-12 * u.dimensionless
         )
 
-        interpolator = _ComplexInterpolator(theta, phi, None, values, floor=floor)
+        # Test conjugation: Interp(conj(V)) == conj(Interp(V))
+        interpolator_conj = _ComplexInterpolator(theta, phi, None, np.conj(values))
 
-        # Test upper hemisphere
-        test_theta = np.pi / 4 * u.rad
-        test_phi = np.linspace(0, 2 * np.pi, 100) * u.rad
-        result = interpolator(test_theta, test_phi)
-        expected = np.sin(test_theta.value) * np.exp(1j * test_phi.value)
-        assert_quantity_allclose(result, expected * unit, atol=1e-2 * unit)
+        result_conj = interpolator_conj(test_theta[:, np.newaxis], test_phi)
+        expected_conj = np.conj(interpolator_orig(test_theta[:, np.newaxis], test_phi))
+        assert_quantity_allclose(
+            result_conj, expected_conj, atol=1e-12 * u.dimensionless
+        )
 
-        # Test lower hemisphere
-        test_theta = 3 * np.pi / 4 * u.rad
-        test_phi = np.linspace(0, 2 * np.pi, 100) * u.rad
-        result = interpolator(test_theta, test_phi)
-        expected = 10 ** (floor.value / 10)
-        assert_quantity_allclose(result, floor, atol=1e-10 * unit)
+    def test_convergence_under_refinement(self):
+        """Test that interpolation error decreases monotonically with refinement."""
+
+        def smooth_pattern(theta, phi):
+            """Smooth 2π-periodic complex function for testing convergence."""
+            th = theta.to_value(u.rad)
+            ph = phi.to_value(u.rad)
+            amplitude = 1 + 0.2 * np.sin(th) + 0.1 * np.sin(2 * ph)
+            phase = 0.3 * th + 0.4 * np.sin(ph)
+            return amplitude * np.exp(1j * phase) * u.dimensionless
+
+        # Create evaluation points (avoiding boundaries for robustness)
+        eval_theta = np.linspace(0.1, np.pi - 0.1, 15) * u.rad
+        eval_phi = np.linspace(0.05, 2 * np.pi - 0.05, 20) * u.rad
+        true_values = smooth_pattern(eval_theta[:, np.newaxis], eval_phi)
+
+        errors = []
+        grid_sizes = [(12, 16), (24, 32)]
+
+        for N, M in grid_sizes:
+            theta = np.linspace(0.05, np.pi - 0.05, N) * u.rad
+            phi = np.linspace(0, 2 * np.pi, M, endpoint=False) * u.rad
+            values = smooth_pattern(theta[:, np.newaxis], phi)
+
+            interpolator = _ComplexInterpolator(theta, phi, None, values)
+            result = interpolator(eval_theta[:, np.newaxis], eval_phi)
+
+            error = np.abs(result - true_values).to_value(u.dimensionless).mean()
+            errors.append(error)
+
+        # Error should decrease with refinement (no specific rate assumed)
+        assert errors[1] < errors[0], (
+            f"Error did not decrease: {errors[0]:.2e} -> {errors[1]:.2e}"
+        )
 
     def test_phase_continuity(self):
         theta = np.linspace(0, np.pi, 11) * u.rad
@@ -385,7 +364,6 @@ class TestComplexInterpolator:
 
         interpolator = _ComplexInterpolator(theta, phi, frequency, values)
 
-        # Calling 3D interpolator without frequency should raise error
         with pytest.raises(ValueError):
             interpolator(theta[0], phi[0])
 
@@ -400,39 +378,18 @@ class TestComplexInterpolator:
         with pytest.raises(ValueError):
             interpolator(theta[0], phi[0], f_query)
 
-    def test_floor_validation_errors(self):
-        theta = np.linspace(0, np.pi, 3) * u.rad
-        phi = np.linspace(0, 2 * np.pi, 4, endpoint=False) * u.rad
-        vals = np.ones((3, 4)) * u.dimensionless
-        # Wrong unit
-        with pytest.raises(ValueError):
-            _ComplexInterpolator(theta, phi, None, vals, floor=1e-6 * u.K)
-        # Non-scalar floor (length > 1)
-        with pytest.raises(ValueError):
-            _ComplexInterpolator(
-                theta, phi, None, vals, floor=(np.array([1e-6, 2e-6]) * u.dimensionless)
-            )
-        # Non-positive floor
-        with pytest.raises(ValueError):
-            _ComplexInterpolator(theta, phi, None, vals, floor=0.0 * u.dimensionless)
-
     def test_phi_wrapping_negative_to_positive_range(self):
-        """Test phi ranging from -180° to +180° works after wrapping and sorting fix."""
+        """Test phi ranging from -180° to +180° works."""
         theta = np.linspace(0, np.pi, 20) * u.rad
-        phi = np.linspace(-180, 180, 50) * u.deg  # This caused the original issue
-
-        # Create simple uniform test pattern
+        phi = np.linspace(-180, 180, 50) * u.deg
         values = np.ones((theta.size, phi.size)) * u.dimensionless
 
-        # This should not raise "points in dimension 1 must be strictly ascending"
         interpolator = _ComplexInterpolator(theta, phi, None, values)
 
-        # Verify interpolation works without error
         test_theta = np.pi / 2 * u.rad
         test_phi = np.array([-90, 0, 90]) * u.deg
         result = interpolator(test_theta, test_phi)
 
-        # Should return uniform values
         expected = np.ones(3) * u.dimensionless
         assert_quantity_allclose(result, expected)
 


### PR DESCRIPTION
Modifies the interpolator class in the antenna module to interpolate the E-field in linear scale rather than log scale. Also simplifies the interpolation such that the complex values are interpolated directly rather than handling magnitude and phase separately. These changes result in a roughly 30% speed-up.

The original motivation for using log-scale interpolation of magnitude was to work around numerical instability exhibited by `scipy.interpolate.RectSphereBivariateSpline`, the original interpolator, but this has since been replaced by `RegularGridInterpolator` using linear method which does not have the same challenges.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cascade-space-co/spacelink/63)
<!-- Reviewable:end -->
