### PR TITLE
Minor update to `enforce_unit` helper print statement

### DIFF
--- a/src/spacelink/core/units.py
+++ b/src/spacelink/core/units.py
@@ -207,8 +207,8 @@ def _wrap_function_with_unit_enforcement(func: FuncOrClass) -> FuncOrClass:
                 else:
                     # Handle non-Quantity inputs
                     raise TypeError(
-                        f"Parameter '{name}' must be provided as an astropy Quantity, "
-                        f"not a raw number."
+                        f"Parameter '{name}' must be provided as an astropy Quantity "
+                        f"compatible with {unit}, not a raw number."
                     )
         return func(*bound.args, **bound.kwargs)
 


### PR DESCRIPTION
Clarify unit-enforcement error messages by showing the expected unit with non-Quantity input.

## Previous behaviour
```
>>> from spacelink.core.noise import noise_power
>>> noise_power(23)

TypeError: Parameter 'bandwidth' must be provided as an astropy Quantity, not a raw number.
```

## New behaviour

```
>>> from spacelink.core.noise import noise_power
>>> noise_power(23)

TypeError: Parameter 'bandwidth' must be an Astropy Quantity compatible with Hz, not a raw number.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cascade-space-co/spacelink/65)
<!-- Reviewable:end -->
